### PR TITLE
this.logging

### DIFF
--- a/lib/telebot.js
+++ b/lib/telebot.js
@@ -26,7 +26,7 @@ class TeleBot {
         this.usePlugins = Array.isArray(cfg.usePlugins) ? cfg.usePlugins : [];
         this.defaultPlugins = cfg.defaultPlugins !== undefined ? (cfg.defaultPlugins || []) : DEFAULT_PLUGINS;
         this.pluginConfig = cfg.pluginConfig || {};
-        this.logging = cfg.logging || true;
+        this.logging = cfg.hasOwnProperty('logging') ? cfg.logging : true;
 
         const poll = cfg.polling || {};
 

--- a/lib/telebot.js
+++ b/lib/telebot.js
@@ -94,10 +94,14 @@ class TeleBot {
 
             plugin.call(this, this, config || {});
 
-            if(this.logging) console.log(`[bot.plugin] loaded '${id}' plugin`);
+            if(this.logging) {
+                console.log(`[bot.plugin] loaded '${id}' plugin`);
+            }
 
         } else {
-            if(this.logging) console.log('[bot.plugin] skip plugin without id');
+            if(this.logging) {
+                console.log('[bot.plugin] skip plugin without id');
+            }
         }
 
     }
@@ -121,12 +125,16 @@ class TeleBot {
 
             return this.setWebhook(url, cert, this.allowedUpdates, this.maxConnections).then(() => {
 
-                if(this.logging) console.log(`[bot.webhook] set to "${url}"`);
+                if(this.logging) {
+                    console.log(`[bot.webhook] set to "${url}"`);
+                }
                 return webhook.call(this, this, this.webhook);
 
             }).catch((error) => {
 
-                if(this.logging) console.error('[bot.error.webhook]', error);
+                if(this.logging) {
+                    console.error('[bot.error.webhook]', error);
+                }
                 this.event('error', {error});
 
             });
@@ -138,14 +146,20 @@ class TeleBot {
             f.poll = true;
 
             if (response.description == 'Webhook was deleted') {
-                if(this.logging) console.log('[bot.webhook] webhook was deleted');
+                if(this.logging) {
+                    console.log('[bot.webhook] webhook was deleted');
+                }
             }
 
-            if(this.logging) console.log('[bot.info] bot started');
+            if(this.logging) {
+                console.log('[bot.info] bot started');
+            }
 
         }).catch((error) => {
 
-            if(this.logging) console.error('[bot.error.webhook]', error);
+            if(this.logging) {
+                console.error('[bot.error.webhook]', error);
+            }
             this.event('error', {error});
 
         });
@@ -174,7 +188,9 @@ class TeleBot {
                     const now = Date.now();
                     const diff = (now - f.retry) / 1000;
 
-                    if(this.logging) console.log(`[bot.info.update] reconnected after ${ diff } seconds`);
+                    if(this.logging) {
+                        console.log(`[bot.info.update] reconnected after ${ diff } seconds`);
+                    }
                     this.event('reconnected', {
                         startTime: f.retry, endTime: now, diffTime: diff
                     });
@@ -196,7 +212,9 @@ class TeleBot {
                 // Set retry flag as current date (for timeout calculations)
                 if (f.retry === false) f.retry = Date.now();
 
-                if(this.logging) console.error(`[bot.error.update]`, error.stack || error);
+                if(this.logging) {
+                    console.error(`[bot.error.update]`, error.stack || error);
+                }
                 this.event(['error', 'error.update'], {error});
 
                 return Promise.reject();
@@ -204,7 +222,9 @@ class TeleBot {
             }).catch(() => {
 
                 const seconds = this.retryTimeout / 1000;
-                if(this.logging) console.log(`[bot.info.update] reconnecting in ${ seconds } seconds...`);
+                if(this.logging) {
+                    console.log(`[bot.info.update] reconnecting in ${ seconds } seconds...`);
+                }
                 this.event('reconnecting');
 
                 // Set reconnecting timeout
@@ -224,7 +244,9 @@ class TeleBot {
 
     stop(message) {
         this.flags.looping = false;
-        if(this.logging) console.log(`[bot.info] bot stopped ${ message ? ': ' + message : '' }`);
+        if(this.logging) {
+            console.log(`[bot.info] bot stopped ${ message ? ': ' + message : '' }`);
+        }
         this.event('stop', message);
     }
 
@@ -285,7 +307,9 @@ class TeleBot {
 
         }).catch(error => {
 
-            if(this.logging) console.log('[bot.error]', error.stack || error);
+            if(this.logging) {
+                console.log('[bot.error]', error.stack || error);
+            }
             this.event('error', {error});
 
             // Don't trigger server reconnect
@@ -571,7 +595,9 @@ TeleBot.addMethods(standardMethods);
 
 function eventPromiseError(type, fired, error) {
     return new Promise((resolve, reject) => {
-        if(this.logging) console.error('[bot.error.event]', error.stack || error);
+        if(this.logging) {
+            console.error('[bot.error.event]', error.stack || error);
+        }
         if (type != 'error' && type != 'error.event') {
             this.event(['error', 'error.event'], {error, data: fired.data})
                 .then(resolve).catch(reject);

--- a/lib/telebot.js
+++ b/lib/telebot.js
@@ -94,12 +94,12 @@ class TeleBot {
 
             plugin.call(this, this, config || {});
 
-            if(this.logging) {
+            if (this.logging) {
                 console.log(`[bot.plugin] loaded '${id}' plugin`);
             }
 
         } else {
-            if(this.logging) {
+            if (this.logging) {
                 console.log('[bot.plugin] skip plugin without id');
             }
         }
@@ -125,14 +125,14 @@ class TeleBot {
 
             return this.setWebhook(url, cert, this.allowedUpdates, this.maxConnections).then(() => {
 
-                if(this.logging) {
+                if (this.logging) {
                     console.log(`[bot.webhook] set to "${url}"`);
                 }
                 return webhook.call(this, this, this.webhook);
 
             }).catch((error) => {
 
-                if(this.logging) {
+                if (this.logging) {
                     console.error('[bot.error.webhook]', error);
                 }
                 this.event('error', {error});
@@ -146,18 +146,18 @@ class TeleBot {
             f.poll = true;
 
             if (response.description == 'Webhook was deleted') {
-                if(this.logging) {
+                if (this.logging) {
                     console.log('[bot.webhook] webhook was deleted');
                 }
             }
 
-            if(this.logging) {
+            if (this.logging) {
                 console.log('[bot.info] bot started');
             }
 
         }).catch((error) => {
 
-            if(this.logging) {
+            if (this.logging) {
                 console.error('[bot.error.webhook]', error);
             }
             this.event('error', {error});
@@ -188,7 +188,7 @@ class TeleBot {
                     const now = Date.now();
                     const diff = (now - f.retry) / 1000;
 
-                    if(this.logging) {
+                    if (this.logging) {
                         console.log(`[bot.info.update] reconnected after ${ diff } seconds`);
                     }
                     this.event('reconnected', {
@@ -212,7 +212,7 @@ class TeleBot {
                 // Set retry flag as current date (for timeout calculations)
                 if (f.retry === false) f.retry = Date.now();
 
-                if(this.logging) {
+                if (this.logging) {
                     console.error(`[bot.error.update]`, error.stack || error);
                 }
                 this.event(['error', 'error.update'], {error});
@@ -222,7 +222,7 @@ class TeleBot {
             }).catch(() => {
 
                 const seconds = this.retryTimeout / 1000;
-                if(this.logging) {
+                if (this.logging) {
                     console.log(`[bot.info.update] reconnecting in ${ seconds } seconds...`);
                 }
                 this.event('reconnecting');
@@ -244,7 +244,7 @@ class TeleBot {
 
     stop(message) {
         this.flags.looping = false;
-        if(this.logging) {
+        if (this.logging) {
             console.log(`[bot.info] bot stopped ${ message ? ': ' + message : '' }`);
         }
         this.event('stop', message);
@@ -307,7 +307,7 @@ class TeleBot {
 
         }).catch(error => {
 
-            if(this.logging) {
+            if (this.logging) {
                 console.log('[bot.error]', error.stack || error);
             }
             this.event('error', {error});
@@ -595,7 +595,7 @@ TeleBot.addMethods(standardMethods);
 
 function eventPromiseError(type, fired, error) {
     return new Promise((resolve, reject) => {
-        if(this.logging) {
+        if (this.logging) {
             console.error('[bot.error.event]', error.stack || error);
         }
         if (type != 'error' && type != 'error.event') {

--- a/lib/telebot.js
+++ b/lib/telebot.js
@@ -26,6 +26,7 @@ class TeleBot {
         this.usePlugins = Array.isArray(cfg.usePlugins) ? cfg.usePlugins : [];
         this.defaultPlugins = cfg.defaultPlugins !== undefined ? (cfg.defaultPlugins || []) : DEFAULT_PLUGINS;
         this.pluginConfig = cfg.pluginConfig || {};
+        this.logging = cfg.logging || true;
 
         const poll = cfg.polling || {};
 
@@ -93,10 +94,10 @@ class TeleBot {
 
             plugin.call(this, this, config || {});
 
-            console.log(`[bot.plugin] loaded '${id}' plugin`);
+            if(this.logging) console.log(`[bot.plugin] loaded '${id}' plugin`);
 
         } else {
-            console.log('[bot.plugin] skip plugin without id');
+            if(this.logging) console.log('[bot.plugin] skip plugin without id');
         }
 
     }
@@ -120,12 +121,12 @@ class TeleBot {
 
             return this.setWebhook(url, cert, this.allowedUpdates, this.maxConnections).then(() => {
 
-                console.log(`[bot.webhook] set to "${url}"`);
+                if(this.logging) console.log(`[bot.webhook] set to "${url}"`);
                 return webhook.call(this, this, this.webhook);
 
             }).catch((error) => {
 
-                console.error('[bot.error.webhook]', error);
+                if(this.logging) console.error('[bot.error.webhook]', error);
                 this.event('error', {error});
 
             });
@@ -137,14 +138,14 @@ class TeleBot {
             f.poll = true;
 
             if (response.description == 'Webhook was deleted') {
-                console.log('[bot.webhook] webhook was deleted');
+                if(this.logging) console.log('[bot.webhook] webhook was deleted');
             }
 
-            console.log('[bot.info] bot started');
+            if(this.logging) console.log('[bot.info] bot started');
 
         }).catch((error) => {
 
-            console.error('[bot.error.webhook]', error);
+            if(this.logging) console.error('[bot.error.webhook]', error);
             this.event('error', {error});
 
         });
@@ -173,7 +174,7 @@ class TeleBot {
                     const now = Date.now();
                     const diff = (now - f.retry) / 1000;
 
-                    console.log(`[bot.info.update] reconnected after ${ diff } seconds`);
+                    if(this.logging) console.log(`[bot.info.update] reconnected after ${ diff } seconds`);
                     this.event('reconnected', {
                         startTime: f.retry, endTime: now, diffTime: diff
                     });
@@ -195,7 +196,7 @@ class TeleBot {
                 // Set retry flag as current date (for timeout calculations)
                 if (f.retry === false) f.retry = Date.now();
 
-                console.error(`[bot.error.update]`, error.stack || error);
+                if(this.logging) console.error(`[bot.error.update]`, error.stack || error);
                 this.event(['error', 'error.update'], {error});
 
                 return Promise.reject();
@@ -203,7 +204,7 @@ class TeleBot {
             }).catch(() => {
 
                 const seconds = this.retryTimeout / 1000;
-                console.log(`[bot.info.update] reconnecting in ${ seconds } seconds...`);
+                if(this.logging) console.log(`[bot.info.update] reconnecting in ${ seconds } seconds...`);
                 this.event('reconnecting');
 
                 // Set reconnecting timeout
@@ -223,7 +224,7 @@ class TeleBot {
 
     stop(message) {
         this.flags.looping = false;
-        console.log(`[bot.info] bot stopped ${ message ? ': ' + message : '' }`);
+        if(this.logging) console.log(`[bot.info] bot stopped ${ message ? ': ' + message : '' }`);
         this.event('stop', message);
     }
 
@@ -284,7 +285,7 @@ class TeleBot {
 
         }).catch(error => {
 
-            console.log('[bot.error]', error.stack || error);
+            if(this.logging) console.log('[bot.error]', error.stack || error);
             this.event('error', {error});
 
             // Don't trigger server reconnect
@@ -570,7 +571,7 @@ TeleBot.addMethods(standardMethods);
 
 function eventPromiseError(type, fired, error) {
     return new Promise((resolve, reject) => {
-        console.error('[bot.error.event]', error.stack || error);
+        if(this.logging) console.error('[bot.error.event]', error.stack || error);
         if (type != 'error' && type != 'error.event') {
             this.event(['error', 'error.event'], {error, data: fired.data})
                 .then(resolve).catch(reject);


### PR DESCRIPTION
Hide log messages from logging

If I have my own beautiful logger, I don't need redundant messages in my log (also we have events "start", "stop", "error", ...)