### PR TITLE
add infrastructure for asynchronous mods

### DIFF
--- a/lib/telebot.js
+++ b/lib/telebot.js
@@ -256,32 +256,34 @@ class TeleBot {
 
             // Run update list modifiers
             mod = this.modRun('updateList', {
-                updateList, props: extendProps(props, eventProps)
+                updateList, props: extendProps(props, eventProps), promise
             });
 
-            updateList = mod.updateList;
-            props = mod.props;
+            return mod.promise.then(() => {
+              updateList = mod.updateList;
+              props = mod.props;
+              promise = Promise.resolve()
 
-            // Every Telegram update
-            for (let update of updateList) {
+              // Every Telegram update
+              for (let update of updateList) {
 
-                // Update ID
-                const nextId = ++update.update_id;
-                if (this.updateId < nextId) this.updateId = nextId;
+                  // Update ID
+                  const nextId = ++update.update_id;
+                  if (this.updateId < nextId) this.updateId = nextId;
 
-                // Run update modifiers
-                mod = this.modRun('update', {update, props});
+                  // Run update modifiers
+                  mod = this.modRun('update', {update, props, promise});
 
-                update = mod.update;
-                props = mod.props;
+                  update = mod.update;
+                  props = mod.props;
+                  promise = mod.promise
 
-                // Process update
-                promise = promise.then(() => this.processUpdate(update, props));
+                  // Process update
+                  promise = promise.then(() => this.processUpdate(update, props));
+              }
 
-            }
-
-            return promise;
-
+              return promise;
+            })
         }).catch(error => {
 
             console.log('[bot.error]', error.stack || error);
@@ -508,7 +510,7 @@ class TeleBot {
             }
         }
 
-        return (this.modRun('property', {form, options: opt})).form;
+        return this.modRun('property', {form, options: opt, promise: Promise.resolve()});
 
     }
 
@@ -553,7 +555,9 @@ class TeleBot {
                 if (argFn) form = argFn.apply(this, args);
                 if (optFn) fnOptions = optFn.apply(this, [].concat(form, options));
                 form = this.properties(form, Object.assign(options, fnOptions));
-                return this.request(`/${id}`, form).then(method.then || (re => re && re.result));
+                return form.promise
+                  .then(() => this.request(`/${id}`, form.form))
+                  .then(method.then || (re => re && re.result));
             };
 
         }

--- a/lib/updates.js
+++ b/lib/updates.js
@@ -39,11 +39,11 @@ const updateFunctions = {
         let anyEventFlags = [false, false];
 
         let promise = Promise.resolve();
-        let mod = this.modRun('message', {message: update, props});
+        let mod = this.modRun('message', {message: update, props, promise});
 
         update = mod.message;
         props = mod.props;
-        promise = promise.then(() => mod.promise);
+        promise = mod.promise;
 
         for (let type of MESSAGE_TYPES) {
 
@@ -57,11 +57,11 @@ const updateFunctions = {
             props.type = type;
 
             // Run message type mod
-            mod = this.modRun(type, {message: update, props});
+            mod = this.modRun(type, {message: update, props, promise});
 
             update = mod.message;
             props = mod.props;
-            promise = promise.then(() => mod.promise);
+            promise = mod.promise;
 
             const eventList = [type];
             if (!anyEventFlags[0]) {

--- a/plugins/regExpMessage.js
+++ b/plugins/regExpMessage.js
@@ -11,8 +11,7 @@ module.exports = {
         bot.mod('text', (data) => {
             const {message, props} = data;
             const text = message.text;
-
-            let promise = Promise.resolve();
+            let promise = data.promise;
 
             for (let eventType of bot.eventList.keys()) {
                 if (eventType instanceof RegExp) {


### PR DESCRIPTION
As issued in #103 its sometimes beneficial to have asynchronous mods.

This PR aims to add this possibility without breaking the current API

This is how its used:

```
  // authentication mod
  bot.mod('message', (data) => {
    if(data.message.text.startsWith('/start')) {
      return data
    }

    data.promise = data.promise.then(() => getUser(data.message.from.id)).then((user) => {
      data.message.user = user
      if(!user) {
        bot.sendMessage(data.message.from.id, 'User unknown');
        throw new Error('User unknown')
      }
    })

    return data
  })
```

Every other mod which waits for `data.promise()` can be sure to have the user set in `data.message.user`.
And when the request reaches `bot.on('text', () => {})` you can be sure that the user was authenticated.

Cons: To cancel the current request I throw an error (so the promise is rejected).
This is gracefully catched by the telebot lib itself but shows up as dirty error in the logs even if its just an authentication middleware which decided that the request can be dropped immediately.
Furthermore it is not really clear in which order the mods are executed. So you have to be careful

That could be done better but would need more rewriting.