### PR TITLE
Add a socketTimeout option to timeout http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ const bot = new TeleBot({
         limit: 100, // Optional. Limits the number of updates to be retrieved.
         retryTimeout: 5000, // Optional. Reconnecting timeout (in ms).
         proxy: 'http://username:password@yourproxy.com:8080' // Optional. An HTTP proxy to be used.
+        socketTimeout: 30000, // Optional. Socket timeout (in ms).
     },
     webhook: { // Optional. Use webhook instead of polling.
         key: 'key.pem', // Optional. Private key for server.

--- a/lib/telebot.js
+++ b/lib/telebot.js
@@ -39,6 +39,7 @@ class TeleBot {
         this.interval = poll.interval >= 0 ? poll.interval : 300;
         this.timeout = poll.timeout >= 0 ? poll.timeout : 0;
         this.retryTimeout = poll.retryTimeout >= 0 ? poll.retryTimeout : 5000;
+        this.socketTimeout = poll.socketTimeout >=0 ? poll.socketTimeout: 30000;
 
         this.webhook = cfg.webhook;
 
@@ -300,7 +301,8 @@ class TeleBot {
 
         const options = {
             url: this.api + url,
-            json: true
+            json: true,
+            timeout: this.socketTimeout
         };
 
         if (this.proxy) options.proxy = this.proxy;


### PR DESCRIPTION
Add an option named socketTimeout for polling to set a socket read timeout for http requests to telegram. The default value is set to 30 seconds. 
Otherwise there is no socket read timeout and connection can hang indefinitely on some systems.