### PR TITLE
Added an option to skip httpServer creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ const bot = new TeleBot({
         proxy: 'http://username:password@yourproxy.com:8080' // Optional. An HTTP proxy to be used.
     },
     webhook: { // Optional. Use webhook instead of polling.
+        createServer: true, //Optional. Specifies whether httpServer or httpsServer instance should be created or not. Defaults to true. When set to false, bot.start() returns a promise which resolves with a listener function to be attached to the server manually. 
         key: 'key.pem', // Optional. Private key for server.
         cert: 'cert.pem', // Optional. Public key.
         url: 'https://....', // HTTPS url to send updates to.
@@ -313,7 +314,7 @@ Creates inlineKeyboard object for answerList articles.
 
 ##### `start()`
 
-Start polling updates.
+Start polling updates. If createServer is set to false in webhook options, then the method returns a promise resolving to a listener function suitable for usage with httpServer/httpsServer createServer method.
 
 ##### `stop(<message>)`
 

--- a/examples/webhook-custom-http-server.js
+++ b/examples/webhook-custom-http-server.js
@@ -1,0 +1,16 @@
+const TeleBot = require('../');
+
+const bot = new TeleBot({
+    token: 'TELEGRAM_BOT_TOKEN',
+    webhook: {
+        createServer: false,
+        url: 'https://....'
+    }
+});
+
+bot.on('text', msg => bot.sendMessage(msg.from.id, msg.text));
+
+bot.start().then(listener => {
+    const server = http.createServer(listener);
+    server.listen(3200, '0.0.0.0');
+});

--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -27,6 +27,7 @@ module.exports = (bot, opt) => {
             }
         });
     }else{
+        // Server will be created by consumer, just return the listener
         return listener;
     }
 


### PR DESCRIPTION
In some scenarios, the webhook can be just one route in a bigger web server, which sets up its own node httpServer.
In this case, the current implementation of Telebot will attempt to create its httpServer on the same host and port which will result in a conflict.
To avoid this, a new option is added which specifies that httpServer should not be created and that bot.start() should return a promise resolving to a listener function which then should be mounted manually onto the existing httpServer.