### PR TITLE
fix connection timeout in wrong requests

### DIFF
--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -49,7 +49,7 @@ module.exports = (bot, opt) => {
 
             });
 
-        }
+        } else res.end();
 
     }
 


### PR DESCRIPTION
when deploying to Azure Web Apps, project unable to work in web hook mode due to "HTTP ping timeout". fixed by closing connection if request is wrong.