### PR TITLE
#173 Set timeout for requests to prevent endless-calls

### DIFF
--- a/lib/telebot.js
+++ b/lib/telebot.js
@@ -347,7 +347,8 @@ class TeleBot {
 
         const options = {
             url: this.api + url,
-            json: true
+            json: true,
+            timeout: 30000 // Timeout any requests taking longer than 30 seconds
         };
 
         if (this.proxy) options.proxy = this.proxy;


### PR DESCRIPTION
Would set a timeout for the request call to 30 seconds. 