### PR TITLE
Send media group error

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,9 +374,9 @@ Use this method to send video files, Telegram clients support `mp4` videos (othe
 
 Use this method to send video messages.
 
-##### `sendMediaGroup(<chat_id>, <media: InputMedia>)`
+##### `sendMediaGroup(<chat_id>, <mediaList: InputMedia[]>)`
 
-Use this method to send a group of photos or videos as an album.
+Use this method to send a group of photos or videos as an album. (Min. 2)
 
 ##### `sendVoice(<chat_id>, <file_id | path | url | buffer | stream>, {duration, caption, fileName, serverDownload, replyToMessage, replyMarkup, notification})`
 

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -282,10 +282,11 @@ const methods = {
     },
 
     sendMediaGroup: {
-        arguments: ['chat_id'],
-        options(form, media) {
-            form.media = JSON.stringify(media);
-            return form;
+        arguments(chat_id, mediaList) {
+            return {
+                chat_id,
+                media: JSON.stringify(mediaList)
+            };
         }
     },
 

--- a/test/index.js
+++ b/test/index.js
@@ -194,6 +194,12 @@ const sendMethods = {
     sendVoice: {
         'buffer': fs.readFileSync(`${__dirname}/data/voice.m4a`),
         'file system': `${__dirname}/data/voice.m4a`
+    },
+    sendMediaGroup: {
+        'mediaList': [
+            { type: 'photo', media: 'https://telegram.org/img/t_logo.png' },
+            { type: 'video', media: 'http://techslides.com/demos/sample-videos/small.mp4'}
+        ]
     }
 };
 


### PR DESCRIPTION
This PR fixes the error 'Bad Request: expected Array of InputMedia' when using the sendMediaGroup method.

I added a test for it in the test cases.