### PR TITLE
Fixing bug in example edit-markup.js

### DIFF
--- a/examples/edit-markup.js
+++ b/examples/edit-markup.js
@@ -11,7 +11,7 @@ bot.on('/start', msg => {
         msg.from.id, 'This is a editMessageReplyMarkup example. So, apples or oranges?', {markup}
     ).then(re => {
         // Start updating message
-        lastMessage = [msg.from.id, re.result.message_id];
+        lastMessage = [msg.from.id, re.message_id];
     });
 
 });


### PR DESCRIPTION
As of the current version of Telegram API, at line 14, the correct way to access the message_id from the "re" object is : re.message_id 
NOT re.result.message_id

The current code returns the following error as re.result is undefined:

[bot.error.event] TypeError: Cannot read property 'message_id' of undefined